### PR TITLE
Update: 투두의 엔트리 삭제

### DIFF
--- a/src/component/TodoList.js
+++ b/src/component/TodoList.js
@@ -4,7 +4,19 @@ import SearchView from "./SearchView";
 const TodoList = props => {
   const [selectedEntryIndex, setSelectedEntryIndex] = useState(-1);
   const onClickEntry = index => () => setSelectedEntryIndex(index);
-  const deleteTodyEntry = () => {};
+  const deleteTodyEntry = () => {
+    const filteredTodoItems = props.todoItems.map(todoItem =>
+      todoItem.selectTitle === props.selectTitle
+        ? {
+            ...todoItem,
+            entries: todoItem.entries.filter(
+              (entry, index) => index !== selectedEntryIndex,
+            ),
+          }
+        : todoItem,
+    );
+    props.setNewTodoEntry(filteredTodoItems);
+  };
   const addTodoEntry = () => {
     if (props.selectTitle === "") {
       alert("select Title!");


### PR DESCRIPTION
이 부분이 너무 아쉽다... 애초에 투두 데이터 전체를 props로 내려버리니까,  엔트리를 골라낼 때 선택한 투두를 골라내고 거기에 삭제할 엔트리도 골라내야 한다..
전체 투두를 내려준 이유는 검색 했을 때, 모든 투두에 대한 검색 내역을 보여주기 위해서였는데, 생각해보니 검색했을때 보여주는 컴포넌트를 굳이 TodoList 컴포넌트 안에 안넣어도 되었네..